### PR TITLE
Test we get the correct start of the pg db_uri in our environment variable

### DIFF
--- a/tests/functional/test_integration.py
+++ b/tests/functional/test_integration.py
@@ -32,4 +32,4 @@ async def test_workload_psql_var(ops_test: OpsTest, app: Application):
     address = status["applications"]["gunicorn-k8s"]["units"][unit]["address"]
     response = requests.get(f"http://{address}")
     assert response.status_code == 200
-    assert "TEST_ENV_VAR" in response.text
+    assert "TEST_ENV_VAR: postgresql://gunicorn-k8s:" in response.text


### PR DESCRIPTION
Include more complete test for output to confirm we get the initial part of the `{{ pg.db_uri }}` in functional test output when related to postgresql-k8s.