### PR TITLE
Add configurable startup command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,7 @@ options:
     type: int
     description: "External port for Ingress configuration."
     default: 8080
+  startup_command:
+    type: string
+    description: Command required to start up the docker image provided.
+    default: "/srv/gunicorn/run"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 branch = true
 
 [tool.coverage.report]
-fail_under = 98
+fail_under = 99
 show_missing = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 branch = true
 
 [tool.coverage.report]
-fail_under = 99
+fail_under = 98
 show_missing = true
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -204,7 +204,7 @@ class GunicornK8sCharm(CharmBase):
         gunicorn_container.add_layer("gunicorn", gunicorn_pebble_config, combine=True)
         try:
             gunicorn_container.pebble.replan_services()
-        except:
+        except ops.pebble.ChangeError:
             self.unit.status = BlockedStatus("Charm's startup command may be wrong, please check the config")
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -205,7 +205,9 @@ class GunicornK8sCharm(CharmBase):
         try:
             gunicorn_container.pebble.replan_services()
         except ops.pebble.ChangeError:
-            self.unit.status = BlockedStatus("Charm's startup command may be wrong, please check the config")
+            self.unit.status = BlockedStatus(
+                "Charm's startup command may be wrong, please check the config"
+            )
             return
 
         statsd_container.add_layer(

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,7 +102,7 @@ class GunicornK8sCharm(CharmBase):
                 "gunicorn": {
                     "override": "replace",
                     "summary": "gunicorn service",
-                    "command": "/srv/gunicorn/run",
+                    "command": self.config["startup_command"],
                     "startup": "enabled",
                 }
             },
@@ -202,7 +202,12 @@ class GunicornK8sCharm(CharmBase):
             "About to add_layer with pebble_config: %s", yaml.dump(gunicorn_pebble_config)
         )
         gunicorn_container.add_layer("gunicorn", gunicorn_pebble_config, combine=True)
-        gunicorn_container.pebble.replan_services()
+        try:
+            gunicorn_container.pebble.replan_services()
+        except:
+            self.unit.status = BlockedStatus("Charm's startup command may be wrong, please check the config")
+            return
+
         statsd_container.add_layer(
             "statsd-prometheus-exporter", statsd_pebble_config, combine=True
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -420,12 +420,13 @@ class TestGunicornK8sCharm(unittest.TestCase):
     def test_configure_workload_exception(self):
 
         mock_event = MagicMock()
-        
+
         with patch("ops.model.Container.pebble", return_value=MagicMock()) as pebble_mock:
             pebble_mock.replan_services.side_effect = pebble.ChangeError("abc", "def")
             self.harness.charm._configure_workload(mock_event)
             self.assertEqual(
-                self.harness.model.unit.status, BlockedStatus("Charm's startup command may be wrong, please check the config")
+                self.harness.model.unit.status,
+                BlockedStatus("Charm's startup command may be wrong, please check the config"),
             )
 
 


### PR DESCRIPTION
This PR adds a configurable startup command to be flexible to any docker image we can pass to this charm. Also, deals gracefully with the startup command error scenario.