### PR TITLE
Charm default to app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The charm also supports the `ingress` relation, which can be used with
     juju relate gunicorn-k8s:ingress nginx-ingress-integrator:ingress
 
 Once the deployment has completed and the "gunicorn-k8s" workload state in
-`juju status` has changed to "active" you can visit `http://gunicorn` in
-a browser (assuming `gunicorn` resolves to the IP(s) of your k8s ingress) or the juju unit's
+`juju status` has changed to "active" you can visit `http://gunicorn-k8s` in
+a browser (assuming `gunicorn-k8s` resolves to the IP(s) of your k8s ingress) or the juju unit's
 (gunicorn-k8s) assigned IP, and you'll be presented with a screen
 that details all the environment variables used by the deployed docker image.
 

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ options:
   external_hostname:
     type: string
     description: >
-      External hostname this gunicorn app should respond to (required).
+      External hostname this gunicorn app should respond to.
       If left blank, the juju application name will be used.
     default: ""
   external_port:

--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,9 @@ options:
     default: ''
   external_hostname:
     type: string
-    description: "External hostname this gunicorn app should respond to (required)."
+    description: >
+      External hostname this gunicorn app should respond to (required).
+      If left blank, the juju application name will be used.
     default: ""
   external_port:
     type: int

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ options:
   external_hostname:
     type: string
     description: "External hostname this gunicorn app should respond to (required)."
-    default: "foo.internal"
+    default: ""
   external_port:
     type: int
     description: "External port for Ingress configuration."

--- a/src/charm.py
+++ b/src/charm.py
@@ -67,7 +67,7 @@ class GunicornK8sCharm(CharmBase):
         self.ingress = IngressRequires(
             self,
             {
-                "service-hostname": self._check_external_hostname(
+                "service-hostname": self._assign_external_hostname(
                     self.config["external_hostname"]
                 ),
                 "service-name": self.app.name,
@@ -93,7 +93,7 @@ class GunicornK8sCharm(CharmBase):
         if initial != self._stored.reldata["mongodb"]:
             self._configure_workload(event)
 
-    def _check_external_hostname(self, hostname):
+    def _assign_external_hostname(self, hostname) -> str:
         if hostname == "":
             hostname = self.app.name
         return hostname
@@ -187,7 +187,7 @@ class GunicornK8sCharm(CharmBase):
         # Ensure the ingress relation has the external hostname.
         self.ingress.update_config(
             {
-                "service-hostname": self._check_external_hostname(
+                "service-hostname": self._assign_external_hostname(
                     self.config["external_hostname"]
                 ),
                 "service-port": self.config["external_port"],

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,7 +20,6 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 
 logger = logging.getLogger(__name__)
 
-REQUIRED_JUJU_CONFIG = ["external_hostname"]
 JUJU_CONFIG_YAML_DICT_ITEMS = ["environment"]
 
 
@@ -68,7 +67,7 @@ class GunicornK8sCharm(CharmBase):
         self.ingress = IngressRequires(
             self,
             {
-                "service-hostname": self.config["external_hostname"],
+                "service-hostname": self._check_external_hostname(self.config["external_hostname"]),
                 "service-name": self.app.name,
                 "service-port": self.config["external_port"],
             },
@@ -91,6 +90,11 @@ class GunicornK8sCharm(CharmBase):
         )
         if initial != self._stored.reldata["mongodb"]:
             self._configure_workload(event)
+    
+    def _check_external_hostname(self, hostname):
+        if hostname == "":
+            hostname = self.app.name
+        return hostname
 
     def _get_gunicorn_pebble_config(self, event: ops.framework.EventBase) -> dict:
         """Generate gunicorn's container pebble config."""
@@ -177,15 +181,11 @@ class GunicornK8sCharm(CharmBase):
             # Charm will be in blocked status.
             return
         statsd_pebble_config = self._get_statsd_pebble_config(event)
-        juju_conf = self._check_juju_config()
-        if juju_conf:
-            self.unit.status = BlockedStatus(str(juju_conf))
-            return {}
 
         # Ensure the ingress relation has the external hostname.
         self.ingress.update_config(
             {
-                "service-hostname": self.config["external_hostname"],
+                "service-hostname": self._check_external_hostname(self.config["external_hostname"]),
                 "service-port": self.config["external_port"],
             }
         )
@@ -265,20 +265,6 @@ class GunicornK8sCharm(CharmBase):
         self._stored.reldata["pg"]["ro_uris"] = [c.uri for c in event.standbys]
 
         # TODO: Emit event when we add support for read replicas
-
-    def _check_juju_config(self) -> None:
-        """Check if all the required Juju config options are set,
-        and if all the Juju config options are properly formatted
-        """
-
-        # Verify required items
-        errors = []
-        for required in REQUIRED_JUJU_CONFIG:
-            if not self.model.config[required]:
-                logger.error("Required Juju config item not set : %s", required)
-                errors.append(required)
-        if errors:
-            return "Required Juju config item(s) not set : {}".format(", ".join(sorted(errors)))
 
     def _render_template(self, tmpl: str, ctx: dict) -> str:
         """Render a Jinja2 template

--- a/src/charm.py
+++ b/src/charm.py
@@ -67,9 +67,7 @@ class GunicornK8sCharm(CharmBase):
         self.ingress = IngressRequires(
             self,
             {
-                "service-hostname": self._assign_external_hostname(
-                    self.config["external_hostname"]
-                ),
+                "service-hostname": self._get_external_hostname(),
                 "service-name": self.app.name,
                 "service-port": self.config["external_port"],
             },
@@ -93,7 +91,10 @@ class GunicornK8sCharm(CharmBase):
         if initial != self._stored.reldata["mongodb"]:
             self._configure_workload(event)
 
-    def _assign_external_hostname(self, hostname) -> str:
+    def _get_external_hostname(self) -> str:
+        """Assign the hostname according to the config option.
+        If empty, default to the app name."""
+        hostname = self.config["external_hostname"]
         if hostname == "":
             hostname = self.app.name
         return hostname
@@ -187,9 +188,7 @@ class GunicornK8sCharm(CharmBase):
         # Ensure the ingress relation has the external hostname.
         self.ingress.update_config(
             {
-                "service-hostname": self._assign_external_hostname(
-                    self.config["external_hostname"]
-                ),
+                "service-hostname": self._get_external_hostname(),
                 "service-port": self.config["external_port"],
             }
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -67,7 +67,9 @@ class GunicornK8sCharm(CharmBase):
         self.ingress = IngressRequires(
             self,
             {
-                "service-hostname": self._check_external_hostname(self.config["external_hostname"]),
+                "service-hostname": self._check_external_hostname(
+                    self.config["external_hostname"]
+                ),
                 "service-name": self.app.name,
                 "service-port": self.config["external_port"],
             },
@@ -90,7 +92,7 @@ class GunicornK8sCharm(CharmBase):
         )
         if initial != self._stored.reldata["mongodb"]:
             self._configure_workload(event)
-    
+
     def _check_external_hostname(self, hostname):
         if hostname == "":
             hostname = self.app.name
@@ -185,7 +187,9 @@ class GunicornK8sCharm(CharmBase):
         # Ensure the ingress relation has the external hostname.
         self.ingress.update_config(
             {
-                "service-hostname": self._check_external_hostname(self.config["external_hostname"]),
+                "service-hostname": self._check_external_hostname(
+                    self.config["external_hostname"]
+                ),
                 "service-port": self.config["external_port"],
             }
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,6 @@ from ops import pebble, testing
 from ops.model import BlockedStatus
 from scenario import (
     JUJU_DEFAULT_CONFIG,
-    TEST_JUJU_CONFIG,
     TEST_PG_CONNSTR,
     TEST_PG_URI,
     TEST_RENDER_TEMPLATE,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -270,6 +270,24 @@ class TestGunicornK8sCharm(unittest.TestCase):
 
         self.assertEqual(sorted(logger.output), expected_output)
 
+    def test_get_external_hostname_not_empty(self):
+
+        self.harness.update_config(JUJU_DEFAULT_CONFIG)
+        self.harness.update_config({"external_hostname": "123"})
+        expected_ret = "123"
+
+        r = self.harness.charm._get_external_hostname()
+        self.assertEqual(r, expected_ret)
+
+    def test_get_external_hostname_empty(self):
+
+        self.harness.update_config(JUJU_DEFAULT_CONFIG)
+        self.harness.update_config({"external_hostname": ""})
+        expected_ret = "gunicorn-k8s"
+
+        r = self.harness.charm._get_external_hostname()
+        self.assertEqual(r, expected_ret)
+
     def test_make_pod_env_empty_conf(self):
         """Test the _make_pod_env function."""
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -176,25 +176,6 @@ class TestGunicornK8sCharm(unittest.TestCase):
             mock_configure_workload.assert_called_once()
             self.assertEqual(self.harness.charm._stored.reldata, expected_data)
 
-    def test_check_juju_config(self):
-        """Check the required juju settings."""
-        self.harness.update_config(JUJU_DEFAULT_CONFIG)
-
-        for scenario, values in TEST_JUJU_CONFIG.items():
-            with self.subTest(scenario=scenario):
-                self.harness.update_config(values["config"])
-                if values["expected"]:
-                    with self.assertLogs(level="ERROR") as logger:
-                        self.harness.charm._check_juju_config()
-                    self.assertEqual(sorted(logger.output), sorted(values["logger"]))
-                else:
-                    self.assertEqual(self.harness.charm._check_juju_config(), None)
-
-                # You need to clean the config after each run
-                # See https://github.com/canonical/operator/blob/master/ops/testing.py#L415
-                # The second argument is the list of key to reset
-                self.harness.update_config(JUJU_DEFAULT_CONFIG)
-
     def test_render_template(self):
         """Test template rendering."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
 description = Run integration tests
 deps =
     pytest
-    juju
+    juju==3.0.2
     pytest-operator
     pytest-asyncio
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This PR aims to change the default value of the external_hostname config value to an empty string, and add code to make it default to the app name when the string is empty.