### PR TITLE
workload ready bug fixed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -32,6 +32,7 @@ class GunicornK8sCharm(CharmBase):
 
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.gunicorn_pebble_ready, self._on_gunicorn_pebble_ready)
+        self.framework.observe(self.on.statsd_prometheus_exporter_pebble_ready, self._on_statsd_prometheus_exporter_pebble_ready)
 
         # Provide ability for Gunicorn to be scraped by Prometheus using prometheus_scrape
         self._metrics_endpoint = MetricsEndpointProvider(
@@ -173,6 +174,11 @@ class GunicornK8sCharm(CharmBase):
         self._configure_workload(event)
 
     def _on_gunicorn_pebble_ready(self, event: ops.framework.EventBase) -> None:
+        """Handle the workload ready event."""
+
+        self._configure_workload(event)
+
+    def _on_statsd_prometheus_exporter_pebble_ready(self, event: ops.framework.EventBase) -> None:
         """Handle the workload ready event."""
 
         self._configure_workload(event)

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,7 +32,10 @@ class GunicornK8sCharm(CharmBase):
 
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.gunicorn_pebble_ready, self._on_gunicorn_pebble_ready)
-        self.framework.observe(self.on.statsd_prometheus_exporter_pebble_ready, self._on_statsd_prometheus_exporter_pebble_ready)
+        self.framework.observe(
+            self.on.statsd_prometheus_exporter_pebble_ready,
+            self._on_statsd_prometheus_exporter_pebble_ready,
+        )
 
         # Provide ability for Gunicorn to be scraped by Prometheus using prometheus_scrape
         self._metrics_endpoint = MetricsEndpointProvider(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -393,6 +393,15 @@ class TestGunicornK8sCharm(unittest.TestCase):
         r = self.harness.charm._on_gunicorn_pebble_ready(mock_event)
         self.assertEqual(r, expected_ret)
 
+    def test_on_statsd_prometheus_exporter_pebble_ready(self):
+        """Test the _on_statsd_prometheus_exporter_pebble_ready function."""
+
+        mock_event = MagicMock()
+        expected_ret = None
+
+        r = self.harness.charm._on_gunicorn_pebble_ready(mock_event)
+        self.assertEqual(r, expected_ret)
+
     def test_configure_workload_no_problem(self):
         """Test the _configure_workload function."""
 
@@ -408,7 +417,14 @@ class TestGunicornK8sCharm(unittest.TestCase):
         expected_ret = None
         expected_output = "waiting for pebble to start"
         with patch("ops.model.Container.can_connect") as can_connect:
-            can_connect.return_value = False
+            can_connect.side_effect = [False, True]
+
+            with self.assertLogs(level="DEBUG") as logger:
+                r = self.harness.charm._configure_workload(mock_event)
+                self.assertEqual(r, expected_ret)
+            self.assertTrue(expected_output in logger.output[0])
+        with patch("ops.model.Container.can_connect") as can_connect:
+            can_connect.side_effect = [True, False]
 
             with self.assertLogs(level="DEBUG") as logger:
                 r = self.harness.charm._configure_workload(mock_event)


### PR DESCRIPTION
This PR fixes the following behaviour: "If you deploy the gunicorn-k8s charm from the stable channel and then gunicorn workload is ready before the statsd workload, the charm will never reach active/idle status."