### PR TITLE
Adapt integration tests to reuse the packed charm

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,4 +10,5 @@ def pytest_addoption(parser):
     Args:
         parser: Pytest parser.
     """
+    parser.addoption("--charm-file", action="store")
     parser.addoption("--gunicorn-image", action="store")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,6 +49,7 @@ def influx_model_name():
 @pytest_asyncio.fixture(scope="module")
 async def app(
     ops_test: OpsTest,
+    charm_file: str,
     gunicorn_image: str,
     statsd_exporter_image: str,
     influx_model_name: str,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,6 +26,7 @@ def gunicorn_image(pytestconfig: pytest.Config):
     assert value is not None, "please specify the --gunicorn-image command line option"
     yield value
 
+
 @pytest.fixture(scope="module")
 def charm_file(pytestconfig: pytest.Config):
     """Get the gunicorn image."""


### PR DESCRIPTION
Adapt the integration tests to reuse the exisintg charm artifact as per https://github.com/canonical/operator-workflows/pull/162