### PR TITLE
Remove auto-fetch from metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -41,7 +41,6 @@ resources:
   statsd-prometheus-exporter-image:
     type: oci-image
     description: Prometheus exporter for statsd data
-    auto-fetch: true
     upstream-source: prom/statsd-exporter
   
 


### PR DESCRIPTION
Remove auto-fetch from metadata as it is redundant